### PR TITLE
Add support for preserving opened tree nodes between page refresh

### DIFF
--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -15,16 +15,15 @@
             this.open = ! this.open;
 
             const sessionKey = this.getSessionKey();
+            let ids = JSON.parse(sessionStorage.getItem(sessionKey)) || [];
 
             if (this.open) {
-                let ids = JSON.parse(sessionStorage.getItem(sessionKey)) || [];
                 if (! ids.includes(this.id)) ids.push(this.id);
-                sessionStorage.setItem(sessionKey, JSON.stringify(ids));
             } else {
-                let ids = JSON.parse(sessionStorage.getItem(sessionKey)) || [];
                 ids = ids.filter(id => id !== this.id);
-                sessionStorage.setItem(sessionKey, JSON.stringify(ids));
             }
+
+            sessionStorage.setItem(sessionKey, JSON.stringify(ids));
         },
     }"
     data-id="{{ $row->getKey() }}"

--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -2,20 +2,16 @@
 
 <div x-data="{
         open: false,
-        page: '{{ str($page)->classBaseName() }}',
         id: '{{ $row->getKey() }}',
-        getSessionKey() {
-            return `${this.page}_opened_nodes`;
-        },
+        sessionKey: '{{ str($page)->classBaseName() }}_opened_nodes',
         init() {
-            let ids = JSON.parse(sessionStorage.getItem(this.getSessionKey())) || [];
+            let ids = JSON.parse(sessionStorage.getItem(this.sessionKey)) || [];
             this.open = ids.includes(this.id);
         },
         toggleOpen() {
             this.open = ! this.open;
 
-            const sessionKey = this.getSessionKey();
-            let ids = JSON.parse(sessionStorage.getItem(sessionKey)) || [];
+            let ids = JSON.parse(sessionStorage.getItem(this.sessionKey)) || [];
 
             if (this.open) {
                 if (! ids.includes(this.id)) ids.push(this.id);
@@ -23,7 +19,7 @@
                 ids = ids.filter(id => id !== this.id);
             }
 
-            sessionStorage.setItem(sessionKey, JSON.stringify(ids));
+            sessionStorage.setItem(this.sessionKey, JSON.stringify(ids));
         },
     }"
     data-id="{{ $row->getKey() }}"

--- a/resources/views/components/row.blade.php
+++ b/resources/views/components/row.blade.php
@@ -1,10 +1,36 @@
 @props(['row', 'page'])
 
-<div x-data="{ open: false }"
-     data-id="{{ $row->getKey() }}"
-     class="js-sortable-item"
-     wire:key="{{ $row->getKey() }}"
-     data-sortable-item
+<div x-data="{
+        open: false,
+        page: '{{ str($page)->classBaseName() }}',
+        id: '{{ $row->getKey() }}',
+        getSessionKey() {
+            return `${this.page}_opened_nodes`;
+        },
+        init() {
+            let ids = JSON.parse(sessionStorage.getItem(this.getSessionKey())) || [];
+            this.open = ids.includes(this.id);
+        },
+        toggleOpen() {
+            this.open = ! this.open;
+
+            const sessionKey = this.getSessionKey();
+
+            if (this.open) {
+                let ids = JSON.parse(sessionStorage.getItem(sessionKey)) || [];
+                if (! ids.includes(this.id)) ids.push(this.id);
+                sessionStorage.setItem(sessionKey, JSON.stringify(ids));
+            } else {
+                let ids = JSON.parse(sessionStorage.getItem(sessionKey)) || [];
+                ids = ids.filter(id => id !== this.id);
+                sessionStorage.setItem(sessionKey, JSON.stringify(ids));
+            }
+        },
+    }"
+    data-id="{{ $row->getKey() }}"
+    class="js-sortable-item"
+    wire:key="{{ $row->getKey() }}"
+    data-sortable-item
 >
     <div class="flex items-center bg-white mb-2 px-2 py-2 rounded shadow justify-between dark:bg-gray-800">
         <div class="flex w-full">
@@ -13,7 +39,7 @@
             </div>
 
             @if ($row->children->count())
-                <div class="flex items-center pr-2" x-on:click="open =! open" x-transition>
+                <div class="flex items-center pr-2" x-on:click="toggleOpen" x-transition>
                     <x-filament::icon x-show="open" icon="heroicon-o-chevron-up" class="w-5 h-5"/>
                     <x-filament::icon x-show="!open" icon="heroicon-o-chevron-right" class="w-5 h-5"/>
                 </div>


### PR DESCRIPTION
This PR enables opened nodes to stay expanded after page refresh by storing information about opened nodes in browser sessionStorage.