### PR TITLE
feat: ability to modify query in pages that extend TreeViewRecords by

### DIFF
--- a/resources/views/list-records.blade.php
+++ b/resources/views/list-records.blade.php
@@ -19,7 +19,7 @@
                     'dark:bg-gray-900 dark:divide-gray/10 dark:border-t-gray/10',
                 ])>
                     <x-filament-tables::empty-state
-                        :heading="__('filament-tables::table.empty.heading')"
+                        :heading="__('filament-tables::table.empty.heading', ['model' => $model])"
                         icon="heroicon-o-x-mark"
                     />
                 </div>

--- a/src/Resources/Pages/TreeViewRecords.php
+++ b/src/Resources/Pages/TreeViewRecords.php
@@ -21,12 +21,18 @@ class TreeViewRecords extends ListRecords
         $this->hasPermissions = config('filament-tree-view.has_permissions', true);
     }
 
+    protected function getTreeQueryBuilder(): Builder
+    {
+        return $this->getModel()::query();
+    }
+
     protected function getViewData(): array
     {
         return [
-            'rows' => $this->getModel()::query()->withDepth()->get()->toTree()->sortBy('_lft'),
+            'rows' => $this->getTreeQueryBuilder()->withDepth()->get()->toTree()->sortBy('_lft'),
             'maxDepth' => $this->getMaxDepth(),
             'sortable' => $this->hasPermissions ? static::getResource()::canReorder() : true,
+            'model' => static::getResource()::getPluralModelLabel(),
         ];
     }
 


### PR DESCRIPTION
1. introduced `getTreeQueryBuilder()` method on `TreeViewRecords` class
- If you need to customize query before passing it to the client component, then you can override getTreeQueryBuilder() component and return customized query builder instance

2. fix: pass plural model label so it can be use for empty state component
- model name is not passed to empty-state translation so this PR fixed that also